### PR TITLE
Replace deprecated python mosquitto library with paho-mqtt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ of MQTT environments.
 
 Contributions welcome!
 
-Requires mosquitto python library 1.x or greater. (1.2 will give arguably
-better performance as the "max messages in flight" parameter can be tweaked)
+Requires paho-mqtt python library
 
 The tools are in multiple layers:
 

--- a/beem/listen.py
+++ b/beem/listen.py
@@ -38,7 +38,7 @@ import tempfile
 import time
 
 import fuse
-import mosquitto
+import paho.mqtt.client as paho
 
 from beem.trackers import ObservedMessage as MsgStatus
 
@@ -55,7 +55,7 @@ class TrackingListener():
         self.options = opts
         self.cid = opts.clientid
         self.log = logging.getLogger(__name__ + ":" + self.cid)
-        self.mqttc = mosquitto.Mosquitto(self.cid)
+        self.mqttc = paho.Mosquitto(self.cid)
         self.mqttc.on_message = self.msg_handler
         self.listen_topic = opts.topic
         self.time_start = None
@@ -265,7 +265,7 @@ topics we are subscribed to.
         print("listener post init init(), path=", path)
         self.cid = self.options.clientid
         self.log = logging.getLogger(__name__ + ":" + self.cid)
-        self.mqttc = mosquitto.Mosquitto(self.cid)
+        self.mqttc = paho.Mosquitto(self.cid)
         self.mqttc.on_message = self.msg_handler
         self.listen_topics = self.options.topic
         # TODO - you _probably_ want to tweak this

--- a/beem/load.py
+++ b/beem/load.py
@@ -33,7 +33,7 @@ import logging
 import math
 import time
 
-import mosquitto
+import paho.mqtt.client as paho
 
 from beem.trackers import SentMessage as MsgStatus
 
@@ -63,7 +63,7 @@ class TrackingSender():
     def __init__(self, host, port, cid):
         self.cid = cid
         self.log = logging.getLogger(__name__ + ":" + cid)
-        self.mqttc = mosquitto.Mosquitto(cid)
+        self.mqttc = paho.Mosquitto(cid)
         self.mqttc.on_publish = self.publish_handler
         # TODO - you _probably_ want to tweak this
         if hasattr(self.mqttc, "max_inflight_messages_set"):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'mosquitto>=1.0',
+        'paho-mqtt',
         'fusepy'
     ],
     tests_require=[

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ envlist = py27, py33
 [testenv]
 commands = {envpython} setup.py test
 deps =
-    mosquitto>=1.0
+    paho-mqtt


### PR DESCRIPTION
This is what I did locally, but I haven't set up my own fork of this project.  This is a good addition IMO, though.