### PR TITLE
Add username/password options

### DIFF
--- a/beem/cmds/publish.py
+++ b/beem/cmds/publish.py
@@ -69,7 +69,7 @@ def _worker(options, proc_num, auth=None):
             cid = auth.split(":")[0]
     else:
         # FIXME - add auth support here too dummy!
-        ts = beem.load.TrackingSender(options.host, options.port, cid)
+        ts = beem.load.TrackingSender(options.host, options.port, options.username, options.password, cid)
 
     # Provide a custom generator
     #msg_gen = my_custom_msg_generator(options.msg_count)
@@ -107,6 +107,12 @@ def add_args(subparsers):
     parser.add_argument(
         "-p", "--port", type=int, default=1883,
         help="Port for remote MQTT host")
+    parser.add_argument(
+        "-u", "--username", default=None,
+        help="Username for MQTT broker authentication")
+    parser.add_argument(
+        "-pw", "--password", default=None,
+        help="MQTT host to connect to")
     parser.add_argument(
         "-q", "--qos", type=int, choices=[0, 1, 2],
         help="set the mqtt qos for messages published", default=1)
@@ -151,7 +157,6 @@ line from the file.  Only as many processes will be made as there are keys""")
         help="""Dump the collected stats into the given JSON file.""")
 
     parser.set_defaults(handler=run)
-
 
 def run(options):
     time_start = time.time()

--- a/beem/cmds/publish.py
+++ b/beem/cmds/publish.py
@@ -68,7 +68,6 @@ def _worker(options, proc_num, auth=None):
         if auth:
             cid = auth.split(":")[0]
     else:
-        # FIXME - add auth support here too dummy!
         ts = beem.load.TrackingSender(options.host, options.port, options.username, options.password, cid)
 
     # Provide a custom generator

--- a/beem/cmds/subscribe.py
+++ b/beem/cmds/subscribe.py
@@ -97,7 +97,7 @@ def add_args(subparsers):
 
 
 def run(options):
-    ts = beem.listen.TrackingListener(options.host, options.port, options)
+    ts = beem.listen.TrackingListener(options.host, options.port, options.username, options.password, options)
     ts.run(options.qos)
     print_stats(ts.stats())
     if options.json is not None:

--- a/beem/listen.py
+++ b/beem/listen.py
@@ -155,7 +155,7 @@ def static_file_attrs(content=None):
     else:
         size = 20
     return {
-            "file": dict(st_mode=(stat.S_IFREG | 0444), st_nlink=1,
+            "file": dict(st_mode=(stat.S_IFREG | 0o0444), st_nlink=1,
                             st_size=size,
                             st_ctime=now, st_mtime=now,
                             st_atime=now),
@@ -165,12 +165,12 @@ def static_file_attrs(content=None):
 
 class MalariaWatcherStatsFS(fuse.LoggingMixIn, fuse.Operations):
 
-    file_attrs = dict(st_mode=(stat.S_IFREG | 0444), st_nlink=1,
+    file_attrs = dict(st_mode=(stat.S_IFREG | 0o0444), st_nlink=1,
                             st_size=20000,
                             st_ctime=time.time(), st_mtime=time.time(),
                             st_atime=time.time())
 
-    dir_attrs = dict(st_mode=(stat.S_IFDIR | 0755),  st_nlink=2,
+    dir_attrs = dict(st_mode=(stat.S_IFDIR | 0o0755),  st_nlink=2,
                             st_ctime=time.time(), st_mtime=time.time(),
                             st_atime=time.time())
     README_STATFS = """

--- a/beem/listen.py
+++ b/beem/listen.py
@@ -51,11 +51,19 @@ class TrackingListener():
 
     msg_statuses = []
 
-    def __init__(self, host, port, opts):
+    def __init__(self, host, port, username, password, opts):
         self.options = opts
         self.cid = opts.clientid
         self.log = logging.getLogger(__name__ + ":" + self.cid)
         self.mqttc = mqtt.Client(self.cid)
+
+        #confirm either both username and password are set, or neither are
+        #https://stackoverflow.com/questions/14350343/python-argparse-either-both-optional-arguments-or-else-neither-one
+        if username and password:
+            self.mqttc.username_pw_set(username=username, password=password)
+        elif bool(username) ^ bool(password):
+            raise Exception('--username and --password must be given together')
+
         self.mqttc.on_message = self.msg_handler
         self.listen_topic = opts.topic
         self.time_start = None

--- a/beem/load.py
+++ b/beem/load.py
@@ -70,7 +70,7 @@ class TrackingSender():
         if username and password:
             self.mqttc.username_pw_set(username=username, password=password)
         elif bool(username) ^ bool(password):
-            Exception('--username and --password must be given together')
+            raise Exception('--username and --password must be given together')
 
         self.mqttc.on_publish = self.publish_handler
         # TODO - you _probably_ want to tweak this

--- a/beem/load.py
+++ b/beem/load.py
@@ -60,10 +60,18 @@ class TrackingSender():
     """
     msg_statuses = {}
 
-    def __init__(self, host, port, cid):
+    def __init__(self, host, port, username, password, cid):
         self.cid = cid
         self.log = logging.getLogger(__name__ + ":" + cid)
         self.mqttc = mqtt.Client(cid)
+
+        #confirm either both username and password are set, or neither are
+        #https://stackoverflow.com/questions/14350343/python-argparse-either-both-optional-arguments-or-else-neither-one
+        if username and password:
+            self.mqttc.username_pw_set(username=username, password=password)
+        elif bool(username) ^ bool(password):
+            Exception('--username and --password must be given together')
+
         self.mqttc.on_publish = self.publish_handler
         # TODO - you _probably_ want to tweak this
         if hasattr(self.mqttc, "max_inflight_messages_set"):

--- a/beem/main.py
+++ b/beem/main.py
@@ -42,7 +42,8 @@ def main():
         Malaria MQTT testing tool
         """)
 
-    subparsers = parser.add_subparsers(title="subcommands")
+    subparsers = parser.add_subparsers(dest="subcommands")
+    subparsers.required = True
 
     beem.cmds.publish.add_args(subparsers)
     beem.cmds.subscribe.add_args(subparsers)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url="https://github.com/etactica/mqtt-malaria",
     maintainer="eTactica ehf. - Software Department",
     maintainer_email="technical@etactica.com",
-    version=version.get_git_version(),
+    version=str(version.get_git_version()),
     description="Attacking MQTT systems with Mosquittos",
     long_description=read('README.md'),
     license="License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Most MQTT brokers support username/password auth functionality so I added the ability to specify them on the command line and connect the MQTT client with the credentials if both are specified.